### PR TITLE
Replace assert with comparison

### DIFF
--- a/src/atp/ClauseSet.java
+++ b/src/atp/ClauseSet.java
@@ -64,8 +64,9 @@ public class ClauseSet {
      * Ignore clause order
      */
     public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
 
-        assert !o.getClass().getName().equals("atp.ClauseSet") : "ClauseSetequals() passed object not of type ClauseSet";
         ClauseSet oc = (ClauseSet) o;
         if (clauses.size() != oc.clauses.size())
             return false;


### PR DESCRIPTION
Assert was testing that object passed for equality testing is
*not* of `atp.ClauseSet` class.
This caused test failures for `ResControlTest`.
Replaced with standart Java equality check boilerplate.