### PR TITLE
Enable assertions for unit tests

### DIFF
--- a/README
+++ b/README
@@ -48,10 +48,10 @@ test on TPTP problems.  It requires that the environment variable $TPTP be set
 to the location of the TPTP problems. The only external libraries needed are for
 jUnit (and its supporting hamcrest library, which are in the lib dir)
 
-java -Xmx7G -cp $GITDIR/JavaRes/build/classes:$GITDIR/JavaRes/lib/*
+java -ea -Xmx7G -cp $GITDIR/JavaRes/build/classes:$GITDIR/JavaRes/lib/*
   org.junit.runner.JUnitCore atp.UnitTestAll
 
-java -Xmx7G -cp $GITDIR/JavaRes/build/classes:$GITDIR/JavaRes/lib/*
+java -ea -Xmx7G -cp $GITDIR/JavaRes/build/classes:$GITDIR/JavaRes/lib/*
   org.junit.runner.JUnitCore atp.ProverFOFTest
 
 -------------------------


### PR DESCRIPTION
Some unit tests rely on java `assert` keyword instead of JUnit assertions.
Java asserts need to be explicitly enabled by passing `-ea` flag to jvm.

Enabling assertions will cause some tests to start failing but I sent other PRs to fix that.